### PR TITLE
Allow enabling support for audio and debug accessories

### DIFF
--- a/hal/Android.bp
+++ b/hal/Android.bp
@@ -18,7 +18,10 @@ cc_defaults {
 
 cc_binary {
     name: "android.hardware.usb@1.2-service-qti",
-    defaults: ["qti_usb_hal_defaults"],
+    defaults: [
+        "qti_usb_hal_defaults",
+        "qti_usb_hal_supported_modes_defaults"
+    ],
     shared_libs: [
         "android.hardware.usb@1.0",
         "android.hardware.usb@1.1",

--- a/hal/Usb.cpp
+++ b/hal/Usb.cpp
@@ -497,6 +497,12 @@ Status getPortStatusHelper(hidl_vec<PortStatus> *currentPortStatus_1_2,
         (*currentPortStatus_1_2)[i].status_1_1.status.supportedModes = V1_0::PortMode::DFP;
       } else {
         (*currentPortStatus_1_2)[i].status_1_1.supportedModes = PortMode_1_1::UFP | PortMode_1_1::DFP;
+#ifdef SUPPORTS_AUDIO_ACCESSORY
+        (*currentPortStatus_1_2)[i].status_1_1.supportedModes |= PortMode_1_1::AUDIO_ACCESSORY;
+#endif
+#ifdef SUPPORTS_DEBUG_ACCESSORY
+        (*currentPortStatus_1_2)[i].status_1_1.supportedModes |= PortMode_1_1::DEBUG_ACCESSORY;
+#endif
         (*currentPortStatus_1_2)[i].status_1_1.status.supportedModes = V1_0::PortMode::NONE;
         (*currentPortStatus_1_2)[i].status_1_1.status.currentMode = V1_0::PortMode::NONE;
 


### PR DESCRIPTION
This effectively allows us to get rid of analog device unsupported notification on devices that can do analog audio just fine. I doubt that anyone will actually need to toggle debug accessory but it doesn't hurt to support it too, does it?

Change-Id: I09b107726e9ba07c940732fd3c628701b7aaec30